### PR TITLE
[17기 김민주] 상품상세 페이지 완료

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7600,6 +7600,16 @@
       "resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
       "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ=="
     },
+    "highcharts": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/highcharts/-/highcharts-9.0.1.tgz",
+      "integrity": "sha512-0UmcCz2RmFuqfT/Igu3h5sGnkeSqqZwfuYrTzJ/htptmJAo5SSxH62NFcTjVRk+3WstoBJmoXR0v5FVGQUzK5A=="
+    },
+    "highcharts-react-official": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/highcharts-react-official/-/highcharts-react-official-3.0.0.tgz",
+      "integrity": "sha512-VefJgDY2hkT9gfppsQGrRF2g5u8d9dtfHGcx2/xqiP+PkZXCqalw9xOeKVCRvJKTOh0coiDFwvVjOvB7KaGl4A=="
+    },
     "history": {
       "version": "4.10.1",
       "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "@testing-library/react": "^11.2.5",
     "@testing-library/user-event": "^12.8.0",
     "font-awesome": "^4.7.0",
+    "highcharts": "^9.0.1",
+    "highcharts-react-official": "^3.0.0",
     "i": "^0.3.6",
     "query-string": "^6.14.1",
     "react": "^17.0.1",

--- a/public/Data/ImageData.json
+++ b/public/Data/ImageData.json
@@ -1,0 +1,66 @@
+{
+  "Items": [
+    {
+      "url_1": [
+        {
+          "src": "https://stockx-360.imgix.net/Air-Jordan-4-Retro-White-Court-Purple/Images/Air-Jordan-4-Retro-White-Court-Purple/Lv2/img01.jpg?auto=format,compress&q=90&updated_at=1606315846&w=1000"
+        },
+        {
+          "src": "https://stockx-360.imgix.net/Air-Jordan-4-Retro-White-Court-Purple/Images/Air-Jordan-4-Retro-White-Court-Purple/Lv2/img36.jpg?auto=format,compress&q=90&updated_at=1606315846&w=400"
+        },
+        {
+          "src": "https://stockx-360.imgix.net/Air-Jordan-4-Retro-White-Court-Purple/Images/Air-Jordan-4-Retro-White-Court-Purple/Lv2/img35.jpg?auto=format,compress&q=90&updated_at=1606315846&w=400"
+        },
+        {
+          "src": "https://stockx-360.imgix.net/Air-Jordan-4-Retro-White-Court-Purple/Images/Air-Jordan-4-Retro-White-Court-Purple/Lv2/img34.jpg?auto=format,compress&q=90&updated_at=1606315846&w=400"
+        },
+        {
+          "src": "https://stockx-360.imgix.net/Air-Jordan-4-Retro-White-Court-Purple/Images/Air-Jordan-4-Retro-White-Court-Purple/Lv2/img33.jpg?auto=format,compress&q=90&updated_at=1606315846&w=400"
+        },
+        {
+          "src": "https://stockx-360.imgix.net/Air-Jordan-4-Retro-White-Court-Purple/Images/Air-Jordan-4-Retro-White-Court-Purple/Lv2/img32.jpg?auto=format,compress&q=90&updated_at=1606315846&w=400"
+        },
+        {
+          "src": "https://stockx-360.imgix.net/Nike-Air-Max-Zero-Essential-White-White-Wolf-Grey/Images/Nike-Air-Max-Zero-Essential-White-White-Wolf-Grey/Lv2/img31.jpg?auto=format,compress&q=90&updated_at=1603481985&w=1000"
+        },
+        {
+          "src": "https://stockx-360.imgix.net/Nike-Air-Max-Zero-Essential-White-White-Wolf-Grey/Images/Nike-Air-Max-Zero-Essential-White-White-Wolf-Grey/Lv2/img30.jpg?auto=format,compress&q=90&updated_at=1603481985&w=1000"
+        },
+        {
+          "src": "https://stockx-360.imgix.net/Nike-Air-Max-Zero-Essential-White-White-Wolf-Grey/Images/Nike-Air-Max-Zero-Essential-White-White-Wolf-Grey/Lv2/img29.jpg?auto=format,compress&q=90&updated_at=1603481985&w=1000"
+        },
+        {
+          "src": "https://stockx-360.imgix.net/Nike-Air-Max-Zero-Essential-White-White-Wolf-Grey/Images/Nike-Air-Max-Zero-Essential-White-White-Wolf-Grey/Lv2/img28.jpg?auto=format,compress&q=90&updated_at=1603481985&w=1000"
+        },
+        {
+          "src": "https://stockx-360.imgix.net/Nike-Air-Max-Zero-Essential-White-White-Wolf-Grey/Images/Nike-Air-Max-Zero-Essential-White-White-Wolf-Grey/Lv2/img27.jpg?auto=format,compress&q=90&updated_at=1603481985&w=1000"
+        },
+        {
+          "src": "https://stockx-360.imgix.net/Nike-Air-Max-Zero-Essential-White-White-Wolf-Grey/Images/Nike-Air-Max-Zero-Essential-White-White-Wolf-Grey/Lv2/img26.jpg?auto=format,compress&q=90&updated_at=1603481985&w=1000"
+        }
+      ]
+    },
+    {
+      "url_2": [
+        {
+          "src": "https://stockx-360.imgix.net/Air-Jordan-4-Retro-White-Court-Purple/Images/Air-Jordan-4-Retro-White-Court-Purple/Lv2/img01.jpg?auto=format,compress&q=90&updated_at=1606315846&w=1000"
+        },
+        {
+          "src": "https://stockx-360.imgix.net/Air-Jordan-4-Retro-White-Court-Purple/Images/Air-Jordan-4-Retro-White-Court-Purple/Lv2/img36.jpg?auto=format,compress&q=90&updated_at=1606315846&w=400"
+        },
+        {
+          "src": "https://stockx-360.imgix.net/Air-Jordan-4-Retro-White-Court-Purple/Images/Air-Jordan-4-Retro-White-Court-Purple/Lv2/img35.jpg?auto=format,compress&q=90&updated_at=1606315846&w=400"
+        },
+        {
+          "src": "https://stockx-360.imgix.net/Air-Jordan-4-Retro-White-Court-Purple/Images/Air-Jordan-4-Retro-White-Court-Purple/Lv2/img34.jpg?auto=format,compress&q=90&updated_at=1606315846&w=400"
+        },
+        {
+          "src": "https://stockx-360.imgix.net/Air-Jordan-4-Retro-White-Court-Purple/Images/Air-Jordan-4-Retro-White-Court-Purple/Lv2/img33.jpg?auto=format,compress&q=90&updated_at=1606315846&w=400"
+        },
+        {
+          "src": "https://stockx-360.imgix.net/Air-Jordan-4-Retro-White-Court-Purple/Images/Air-Jordan-4-Retro-White-Court-Purple/Lv2/img32.jpg?auto=format,compress&q=90&updated_at=1606315846&w=400"
+        }
+      ]
+    }
+  ]
+}

--- a/public/Data/ItemDetailData.json
+++ b/public/Data/ItemDetailData.json
@@ -1,0 +1,379 @@
+{
+  "results": {
+    "product_name": "Nike Air Force 1 Low Supreme White",
+    "product_ticker": "qa923829",
+    "color": "ash pearl",
+    "style": "GTY242",
+    "description": "Jordan Brand adds a twist to a classic with the Air Jordan 1 WMNS Satin “Black Toe”, now available on StockX. Jordan is no stranger to adding satin to the Jordan 1. In May of 2018, they released a satin rendition of the “Shattered Backboard” 1 in a similar fashion, revealing that the release would be in women’s sizing. This AJ 1 features classic “Black Toe” color scheme. This design is constructed in a mix of leather and satin construction providing a luxury feel. A metal Wings logo on the heel completes",
+    "retail_price": 242,
+    "release_date": "2/24/2021",
+    "image_URL": [
+      "https://stockx-360.imgix.net/Air-Jordan-4-Retro-White-Court-Purple/Images/Air-Jordan-4-Retro-White-Court-Purple/Lv2/img01.jpg?auto=format,compress&q=90&updated_at=1606315846&w=1000",
+      "https://stockx-360.imgix.net/Air-Jordan-4-Retro-White-Court-Purple/Images/Air-Jordan-4-Retro-White-Court-Purple/Lv2/img35.jpg?auto=format,compress&q=90&updated_at=1606315846&w=400",
+      "https://stockx-360.imgix.net/Air-Jordan-4-Retro-White-Court-Purple/Images/Air-Jordan-4-Retro-White-Court-Purple/Lv2/img34.jpg?auto=format,compress&q=90&updated_at=1606315846&w=400",
+      "https://stockx-360.imgix.net/Air-Jordan-4-Retro-White-Court-Purple/Images/Air-Jordan-4-Retro-White-Court-Purple/Lv2/img33.jpg?auto=format,compress&q=90&updated_at=1606315846&w=400"
+    ],
+    "sizes": [
+      {
+        "size_id": 1,
+        "size_name": 8,
+        "last_sale": 430,
+        "lowest_ask": 303,
+        "highest_bid": 343,
+        "total_sales": 242,
+        "price_premium": 24,
+        "average_sale_price": 196,
+        "sales_history": [
+          {
+            "sale_price": 279.0,
+            "date": "2020/5/3"
+          },
+          {
+            "sale_price": 279.0,
+            "date": "2020/5/3"
+          },
+          {
+            "sale_price": 279,
+            "date": "2020/5/3"
+          },
+          {
+            "sale_price": 279,
+            "date": "2020/5/3"
+          },
+          {
+            "sale_price": 279,
+            "date": "2020/5/3"
+          },
+          {
+            "sale_price": 279,
+            "date": "2020/5/3"
+          }
+        ]
+      },
+      {
+        "size_id": 2,
+        "size_name": 9,
+        "last_sale": 330,
+        "lowest_ask": 0,
+        "highest_bid": 353,
+        "total_sales": 242,
+        "price_premium": 24,
+        "average_sale_price": 196,
+        "sale_history": [
+          {
+            "sale_price": 279,
+            "date": "2020/5/3"
+          },
+          {
+            "sale_price": 279,
+            "date": "2020/5/3"
+          },
+          {
+            "sale_price": 279,
+            "date": "2020/5/3"
+          },
+          {
+            "sale_price": 279,
+            "date": "2020/5/3"
+          },
+          {
+            "sale_price": 279,
+            "date": "2020/5/3"
+          },
+          {
+            "sale_price": 279,
+            "date": "2020/5/3"
+          }
+        ]
+      },
+      {
+        "size_id": 3,
+        "size_name": 10,
+        "last_sale": 410,
+        "lowest_ask": 255,
+        "highest_bid": 340,
+        "total_sales": 242,
+        "price_premium": 24,
+        "average_sale_price": 196,
+        "sale_history": [
+          {
+            "sale_price": 279,
+            "date": "2020/5/3"
+          },
+          {
+            "sale_price": 279,
+            "date": "2020/5/3"
+          },
+          {
+            "sale_price": 279,
+            "date": "2020/5/3"
+          },
+          {
+            "sale_price": 279,
+            "date": "2020/5/3"
+          },
+          {
+            "sale_price": 279,
+            "date": "2020/5/3"
+          },
+          {
+            "sale_price": 279,
+            "date": "2020/5/3"
+          }
+        ]
+      },
+      {
+        "size_id": 4,
+        "size_name": 8,
+        "last_sale": 400,
+        "lowest_ask": 393,
+        "highest_bid": 423,
+        "total_sales": 242,
+        "price_premium": 24,
+        "average_sale_price": 196,
+        "sale_history": [
+          {
+            "sale_price": 279,
+            "date": "2020/5/3"
+          },
+          {
+            "sale_price": 279,
+            "date": "2020/5/3"
+          },
+          {
+            "sale_price": 279,
+            "date": "2020/5/3"
+          },
+          {
+            "sale_price": 279,
+            "date": "2020/5/3"
+          },
+          {
+            "sale_price": 279,
+            "date": "2020/5/3"
+          },
+          {
+            "sale_price": 279,
+            "date": "2020/5/3"
+          }
+        ]
+      },
+      {
+        "size_id": 5,
+        "size_name": 8,
+        "last_sale": 450,
+        "lowest_ask": 353,
+        "highest_bid": 353,
+        "total_sales": 242,
+        "price_premium": 24,
+        "average_sale_price": 196,
+        "sale_history": [
+          {
+            "sale_price": 279,
+            "date": "2020/5/3"
+          },
+          {
+            "sale_price": 279,
+            "date": "2020/5/3"
+          },
+          {
+            "sale_price": 279,
+            "date": "2020/5/3"
+          },
+          {
+            "sale_price": 279,
+            "date": "2020/5/3"
+          },
+          {
+            "sale_price": 279,
+            "date": "2020/5/3"
+          },
+          {
+            "sale_price": 279,
+            "date": "2020/5/3"
+          }
+        ]
+      },
+      {
+        "size_id": 6,
+        "size_name": 8,
+        "last_sale": 500,
+        "lowest_ask": 353,
+        "highest_bid": 353,
+        "total_sales": 242,
+        "price_premium": 24,
+        "average_sale_price": 196,
+        "sale_history": [
+          {
+            "sale_price": 279,
+            "date": "2020/5/3"
+          },
+          {
+            "sale_price": 279,
+            "date": "2020/5/3"
+          },
+          {
+            "sale_price": 279,
+            "date": "2020/5/3"
+          },
+          {
+            "sale_price": 279,
+            "date": "2020/5/3"
+          },
+          {
+            "sale_price": 279,
+            "date": "2020/5/3"
+          },
+          {
+            "sale_price": 279,
+            "date": "2020/5/3"
+          }
+        ]
+      },
+      {
+        "size_id": 7,
+        "size_name": 8,
+        "last_sale": 480,
+        "lowest_ask": 353,
+        "highest_bid": 353,
+        "total_sales": 242,
+        "price_premium": 24,
+        "average_sale_price": 196,
+        "sale_history": [
+          {
+            "sale_price": 279,
+            "date": "2020/5/3"
+          },
+          {
+            "sale_price": 279,
+            "date": "2020/5/3"
+          },
+          {
+            "sale_price": 279,
+            "date": "2020/5/3"
+          },
+          {
+            "sale_price": 279,
+            "date": "2020/5/3"
+          },
+          {
+            "sale_price": 279,
+            "date": "2020/5/3"
+          },
+          {
+            "sale_price": 279,
+            "date": "2020/5/3"
+          }
+        ]
+      },
+      {
+        "size_id": 8,
+        "size_name": 8,
+        "last_sale": 470,
+        "lowest_ask": 353,
+        "highest_bid": 353,
+        "total_sales": 242,
+        "price_premium": 24,
+        "average_sale_price": 196,
+        "sale_history": [
+          {
+            "sale_price": 279,
+            "date": "2020/5/3"
+          },
+          {
+            "sale_price": 279,
+            "date": "2020/5/3"
+          },
+          {
+            "sale_price": 279,
+            "date": "2020/5/3"
+          },
+          {
+            "sale_price": 279,
+            "date": "2020/5/3"
+          },
+          {
+            "sale_price": 279,
+            "date": "2020/5/3"
+          },
+          {
+            "sale_price": 279,
+            "date": "2020/5/3"
+          }
+        ]
+      },
+      {
+        "size_id": 9,
+        "size_name": 8,
+        "last_sale": 410,
+        "lowest_ask": 353,
+        "highest_bid": 353,
+        "total_sales": 242,
+        "price_premium": 24,
+        "average_sale_price": 196,
+        "sale_history": [
+          {
+            "sale_price": 279,
+            "date": "2020/5/3"
+          },
+          {
+            "sale_price": 279,
+            "date": "2020/5/3"
+          },
+          {
+            "sale_price": 279,
+            "date": "2020/5/3"
+          },
+          {
+            "sale_price": 279,
+            "date": "2020/5/3"
+          },
+          {
+            "sale_price": 279,
+            "date": "2020/5/3"
+          },
+          {
+            "sale_price": 279,
+            "date": "2020/5/3"
+          }
+        ]
+      },
+      {
+        "size_id": 10,
+        "size_name": 8,
+        "last_sale": 490,
+        "lowest_ask": 353,
+        "highest_bid": 353,
+        "total_sales": 242,
+        "price_premium": 24,
+        "average_sale_price": 196,
+        "sale_history": [
+          {
+            "sale_price": 279,
+            "date": "2020/5/3"
+          },
+          {
+            "sale_price": 279,
+            "date": "2020/5/3"
+          },
+          {
+            "sale_price": 279,
+            "date": "2020/5/3"
+          },
+          {
+            "sale_price": 279,
+            "date": "2020/5/3"
+          },
+          {
+            "sale_price": 279,
+            "date": "2020/5/3"
+          },
+          {
+            "sale_price": 279,
+            "date": "2020/5/3"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/public/Data/PortfolioData.json
+++ b/public/Data/PortfolioData.json
@@ -1,0 +1,18 @@
+{
+  "portfolio": [
+    {
+      "name": "Jordan 1 Retro High Dark Mocha",
+      "size": "10.5",
+      "purchase_date": "2020/07/31",
+      "purchase_price": 500,
+      "market_value": 300
+    },
+    {
+      "name": "Jordan 14 Retro Doernbecher (2019)",
+      "size": "9",
+      "purchase_date": "2021/3/1",
+      "purchase_price": 1000,
+      "market_value": 900
+    }
+  ]
+}

--- a/src/Components/TickerComp/TickerComp.js
+++ b/src/Components/TickerComp/TickerComp.js
@@ -1,3 +1,4 @@
+/* eslint-disable prettier/prettier */
 import React, { Component } from "react";
 import styled from "styled-components";
 import Ticker from "react-ticker";
@@ -12,8 +13,8 @@ class TickerComp extends Component {
   }
   componentDidMount() {
     fetch("Data/TickerData.json")
-      .then((res) => res.json())
-      .then((res) => {
+      .then(res => res.json())
+      .then(res => {
         this.setState({
           tickerList: res,
         });
@@ -30,7 +31,7 @@ class TickerComp extends Component {
         <Ticker move={this.state.tickerMove} speed={5}>
           {({ index }) => (
             <>
-              {this.state.tickerList.map((item) => {
+              {this.state.tickerList.map(item => {
                 return (
                   <>
                     <TickerText key={item.id}>{item.text}</TickerText>
@@ -62,15 +63,15 @@ const TickerText = styled.span`
 
 const TickerNum = styled.span`
   margin-left: 10px;
-  color: ${(props) => props.color};
+  color: ${props => props.color};
 `;
 
 const TickerArrow = styled.span`
   margin-right: 10px;
   width: 20px;
   height: 20px;
-  font-size: ${(props) => (props.color === "green" ? "20px" : "17px")};
-  color: ${(props) => props.color};
+  font-size: ${props => (props.color === "green" ? "20px" : "17px")};
+  color: ${props => props.color};
 `;
 const TickerWrapper = styled.footer`
   position: sticky;

--- a/src/Config.js
+++ b/src/Config.js
@@ -1,7 +1,7 @@
-const HOST = "http://10.58.6.175:8000";
+const HOST = "http://10.58.1.47:8000";
 
 export const KAKAOAPI = `${HOST}/user/kakao`;
-
+export const ITEMDETAILAPI = `${HOST}/product/1`;
 export const ORDERAPI = `${HOST}/order`;
 export const itemListHOST = `http://127.0.0.1:8000/product`;
 

--- a/src/Pages/ItemDetail/Components/Container/ItemImage.js
+++ b/src/Pages/ItemDetail/Components/Container/ItemImage.js
@@ -1,0 +1,33 @@
+/* eslint-disable prettier/prettier */
+import React from "react";
+import styled from "styled-components";
+
+export default function ItemImage({ images, imageIdx }) {
+  // const [images, setImages] = useState(0);
+  // useEffect(() => {
+  //   getImages();
+  // }, []);
+
+  // const getImages = () => {
+  //   fetch("./Data/ImageData.json")
+  //     .then(res => res.json())
+  //     .then(res => setImages(res));
+  // };
+
+  return (
+    <Item>
+      <div className="item_image_box">
+        <img src={images?.[imageIdx]} alt="Jordan" />
+      </div>
+    </Item>
+  );
+}
+
+const Item = styled.div`
+  .item_image_box {
+    margin: 0 auto;
+    img {
+      width: 100%;
+    }
+  }
+`;

--- a/src/Pages/ItemDetail/Components/Container/MarketSummary.js
+++ b/src/Pages/ItemDetail/Components/Container/MarketSummary.js
@@ -1,0 +1,36 @@
+import React, { useState } from "react";
+import styled from "styled-components";
+import SizeBox from "./MarketSummary/SizeBox";
+import LastSaleBox from "./MarketSummary/LastSaleBox";
+import ActionButton from "./MarketSummary/ActionButton";
+import SizeModal from "./Modal/SizeModal";
+
+export default function MarketSummary({ sizes, products, updateIdx, dataIdx }) {
+  const [isModalOn, setIsModalOn] = useState(false);
+  const handleModal = () => {
+    setIsModalOn(!isModalOn);
+  };
+  return (
+    <>
+      <Container>
+        <div onClick={() => handleModal()}>
+          <SizeBox sizes={sizes?.[dataIdx].size_name} />
+        </div>
+        <LastSaleBox lastSalePrice={sizes?.[dataIdx].last_sale} />
+        <ActionButton
+          lowestAsk={sizes?.[dataIdx].lowest_ask}
+          highestBid={sizes?.[dataIdx].highest_bid}
+        />
+      </Container>
+      {isModalOn && (
+        <SizeModal sizes={sizes} products={products} updateIdx={updateIdx} />
+      )}
+    </>
+  );
+}
+
+const Container = styled.div`
+  ${({ theme }) => theme.flexCenter};
+  justify-content: start;
+  margin-top: 40px;
+`;

--- a/src/Pages/ItemDetail/Components/Container/MarketSummary/ActionButton.js
+++ b/src/Pages/ItemDetail/Components/Container/MarketSummary/ActionButton.js
@@ -1,0 +1,80 @@
+/* eslint-disable prettier/prettier */
+import React from "react";
+import styled from "styled-components";
+
+export default function ActionButton({ lowestAsk, highestBid }) {
+  // const LowestAsk = lowestAsk?.split("").slice(0, 3).join("");
+  // const HighestBid = highestBid.split("").slice(0, 3).join("");
+
+  return (
+    <ActionButtons>
+      <BuyOrBid>
+        <div className="left_section">
+          <p className="market_price">${lowestAsk}</p>
+          <p className="action_descripton">Lowest Ask</p>
+        </div>
+        <div className="right_section">
+          <p className="market_text">Buy</p>
+          <p className="action_text">or Bid</p>
+        </div>
+      </BuyOrBid>
+      <SellOrAsk>
+        <div className="left_section">
+          <p className="market_price">${highestBid}</p>
+          <p className="action_descripton">Highest Bid</p>
+        </div>
+        <div className="right_section">
+          <p className="market_text">Sell</p>
+          <p className="action_text">or Ask</p>
+        </div>
+      </SellOrAsk>
+    </ActionButtons>
+  );
+}
+
+const ActionButtons = styled.div`
+  ${props => props.theme.flexCenter}
+  margin: 0 4px;
+  height: auto;
+  p {
+    color: white;
+    padding: 4px;
+  }
+  .market_price {
+    font-size: 30px;
+  }
+  .market_text {
+    font-size: 28px;
+  }
+  .action_descripton {
+    font-size: 18px;
+    opacity: 70%;
+  }
+  .action-_text {
+    font-size: 16px;
+  }
+`;
+
+const BuyOrBid = styled.button`
+  ${props => props.theme.flexCenter}
+  background-color: ${props => props.theme.colors.red};
+  margin: 0 16px;
+  padding: 8px 16px;
+  border-radius: 4px;
+  &:hover {
+    transform: scale(1.05);
+    transition: 0.2s;
+  }
+`;
+
+const SellOrAsk = styled.button`
+  ${props => props.theme.flexCenter}
+  background-color: ${props => props.theme.colors.green};
+  margin: 0 12px;
+  padding: 8px 16px;
+  border-radius: 4px;
+  &:hover {
+    transform: scale(1.05);
+    transition: 0.2s;
+  }
+`;

--- a/src/Pages/ItemDetail/Components/Container/MarketSummary/LastSaleBox.js
+++ b/src/Pages/ItemDetail/Components/Container/MarketSummary/LastSaleBox.js
@@ -1,0 +1,30 @@
+import React from "react";
+import styled from "styled-components";
+
+export default function LastSaleBox({ lastSalePrice }) {
+  return (
+    <LastSale>
+      <label>Last Sale</label>
+      <span>${lastSalePrice}</span>
+      <label className="small_red">-$ (-1%)</label>
+    </LastSale>
+  );
+}
+
+const LastSale = styled.div`
+  padding: 0px 10px;
+  margin: 0 8px;
+  label {
+    font-size: 16px;
+    color: lightgray;
+    font-weight: 700;
+  }
+  span {
+    margin-top: 8px;
+    display: block;
+    font-size: 26px;
+  }
+  .small_red {
+    color: #ff5a5f;
+  }
+`;

--- a/src/Pages/ItemDetail/Components/Container/MarketSummary/SizeBox.js
+++ b/src/Pages/ItemDetail/Components/Container/MarketSummary/SizeBox.js
@@ -1,0 +1,36 @@
+import React from "react";
+import styled from "styled-components";
+
+export default function SizeBox({ sizes }) {
+  return (
+    <Size>
+      <label className="size_section">Size</label>
+      <div className="dropdown">
+        <span>{sizes}</span>
+        <span className="dropIcon">⌵</span>
+      </div>
+    </Size>
+  );
+}
+
+const Size = styled.div`
+  padding-right: 24px;
+  align-items: center;
+  border-right: 0.5px solid lightgray;
+  cursor: pointer;
+  .size_section {
+    margin: 0 auto;
+    font-size: 20px;
+    font-weight: 700;
+    color: lightgray;
+  }
+  .dropdown {
+    padding: 20px 0 20px 20px;
+    span {
+      font-size: 30px;
+    }
+    .dropIcon {
+      margin-left: 16px;
+    }
+  }
+`;

--- a/src/Pages/ItemDetail/Components/Container/Modal/SizeBtn.js
+++ b/src/Pages/ItemDetail/Components/Container/Modal/SizeBtn.js
@@ -1,0 +1,51 @@
+import React, { useState } from "react";
+import styled from "styled-components";
+
+export default function SizeBtn({ isButtonOn, sizeName, lowestAsk }) {
+  return (
+    <Container>
+      <button className={isButtonOn ? "buttonOn" : "buttonDown"}>
+        US {sizeName}
+        {lowestAsk === 0 ? (
+          <p className="sell">bid</p>
+        ) : (
+          <p className="buy">${lowestAsk}</p>
+        )}
+      </button>
+    </Container>
+  );
+}
+
+const Container = styled.div`
+  button {
+    width: 74px;
+    height: 60px;
+    margin: 5px;
+    border: 0.5px solid lightgray;
+    font-size: 18px;
+    font-weight: 700;
+
+    &:hover {
+      background-color: #eef7eb;
+      transition: 0.2s;
+    }
+  }
+  .buttonOn {
+    background-color: #eef7eb;
+  }
+
+  .buttonDown {
+    background-color: white;
+  }
+
+  .buy {
+    margin-top: 3px;
+    font-size: 14px;
+    color: green;
+  }
+  .sell {
+    margin-top: 3px;
+    font-size: 14px;
+    color: red;
+  }
+`;

--- a/src/Pages/ItemDetail/Components/Container/Modal/SizeModal.js
+++ b/src/Pages/ItemDetail/Components/Container/Modal/SizeModal.js
@@ -1,0 +1,71 @@
+/* eslint-disable prettier/prettier */
+import React, { useState } from "react";
+import SizeBtn from "./SizeBtn";
+import styled from "styled-components";
+
+export default function SizeModal({ sizes, updateIdx }) {
+  const [buttonIdx, setButtonIdx] = useState(0);
+
+  const handleIdx = buttonId => {
+    setButtonIdx(buttonId);
+    updateIdx(buttonId);
+  };
+
+  return (
+    <Container>
+      <header>
+        <p className="modal_head">Selet A U.S Men's Size</p>
+        <SizeChart>Size Chart</SizeChart>
+      </header>
+      <div className="size_button_container">
+        {sizes.map((size, idx) => {
+          return (
+            <div onClick={() => handleIdx(idx)} key={size.size_id}>
+              <SizeBtn
+                key={size.size_id}
+                sizeName={size.size_name}
+                lowestAsk={size.lowest_ask}
+                isButtonOn={buttonIdx === idx}
+              />
+            </div>
+          );
+        })}
+      </div>
+    </Container>
+  );
+}
+const Container = styled.div`
+  width: 352px;
+  box-shadow: 4px 4px 10px gray;
+  background-color: white;
+  transform: translate(0%, -15%);
+
+  header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 16px 10px 0 10px;
+
+    .modal_head {
+      font-size: 18px;
+      font-weight: 700;
+      padding: 8px 0px 6px 0;
+    }
+  }
+  .size_button_container {
+    ${({ theme }) => theme.flexCenter};
+    height: 250px;
+    justify-content: left;
+    overflow: hidden;
+    flex-wrap: wrap;
+    overflow-y: scroll;
+    scrollbar-width: thin;
+  }
+`;
+
+const SizeChart = styled.button`
+  border: none;
+  font-size: 14px;
+  font-weight: 700;
+  color: green;
+`;

--- a/src/Pages/ItemDetail/Components/Container/ProductInfo.js
+++ b/src/Pages/ItemDetail/Components/Container/ProductInfo.js
@@ -1,0 +1,61 @@
+import React from "react";
+import styled from "styled-components";
+
+function ProductInfo({ product }) {
+  const date = product?.release_date.split("").slice(0, 10).join("");
+  return (
+    <Form>
+      <ProductDetail>
+        <div className="product_info">
+          <span className="info_style">STYLE</span>
+          <span>{product?.style}</span>
+        </div>
+        <div className="product_info">
+          <span className="info_style">COLORWAY</span>
+          <span>{product?.color}</span>
+        </div>
+        <div className="product_info">
+          <span className="info_style">RETAIL PRICE</span>
+          <span>${product?.retail_price}</span>
+        </div>
+        <div className="product_info">
+          <span className="info_style">RELEASE DATE</span>
+          <span>
+            {date}
+            {/* {product?.release_date} */}
+          </span>
+        </div>
+      </ProductDetail>
+      <p>{product?.description}</p>
+    </Form>
+  );
+}
+export default ProductInfo;
+
+const Form = styled.div`
+  ${({ theme }) => theme.flexCenter};
+  justify-content: space-between;
+  width: 100%;
+  height: 217px;
+  overflow: auto;
+  p {
+    width: 80%;
+    line-height: 150%;
+  }
+`;
+
+const ProductDetail = styled.div`
+  width: 340px;
+  margin-right: 40px;
+
+  .product_info {
+    margin-bottom: 10px;
+    .info_style {
+      font-weight: 800;
+    }
+  }
+
+  span {
+    margin-right: 10px;
+  }
+`;

--- a/src/Pages/ItemDetail/Components/Container/ProductSummary.js
+++ b/src/Pages/ItemDetail/Components/Container/ProductSummary.js
@@ -1,0 +1,36 @@
+import React from "react";
+import styled from "styled-components";
+
+export default function ProductSummary({ ticker }) {
+  return (
+    <Section>
+      <span className="samll_basic">Condition:</span>
+      <span className="small_green">New</span>
+      <div className="divider"> </div>
+      <span className="samll_basic"> Ticker: </span>
+      <span className="samll_basic"> {ticker}</span>
+      <div className="divider"> </div>
+      <span className="small_green">100% Authentic</span>
+    </Section>
+  );
+}
+
+const Section = styled.div`
+  display: flex;
+  margin-top: 16px;
+  font-size: 18px;
+  font-weight: 600;
+
+  .small_basic {
+    color: lightgray;
+    padding: 0 6px;
+  }
+  .small_green {
+    color: #08a05c;
+    padding: 0 6px;
+  }
+  .divider {
+    border-left: 1.5px solid black;
+    margin: 2px 6px;
+  }
+`;

--- a/src/Pages/ItemDetail/Components/Container/ScrollSlider.js
+++ b/src/Pages/ItemDetail/Components/Container/ScrollSlider.js
@@ -1,0 +1,52 @@
+/* eslint-disable prettier/prettier */
+import React from "react";
+import styled from "styled-components";
+
+function ScrollSlider({ handleScrollValue }) {
+  return (
+    <Container>
+      <div>
+        <input type="range" min={0} max={25} onChange={handleScrollValue} />
+      </div>
+    </Container>
+  );
+}
+
+export default ScrollSlider;
+
+const Container = styled.div`
+  ${({ theme }) => theme.flexCenter};
+  width: 100%;
+  margin-bottom: 30px;
+
+  div {
+    width: 60%;
+
+    input {
+      flex: 1;
+      -webkit-appearance: none;
+      width: 100%;
+      height: 6px;
+      border-radius: 4px;
+      background-color: #efefef;
+      outline: none;
+      opacity: 0.7;
+      transition: opacity 0.2s;
+
+      &:hover {
+        opacity: 1;
+      }
+
+      &::-webkit-slider-thumb {
+        -webkit-appearance: auto;
+        appearance: none;
+        width: 17px;
+        height: 17px;
+        border: 2px solid;
+        border-radius: 50%;
+        cursor: grab;
+        background-color: #fff;
+      }
+    }
+  }
+`;

--- a/src/Pages/ItemDetail/Components/Container/SocialBtnContainer.js
+++ b/src/Pages/ItemDetail/Components/Container/SocialBtnContainer.js
@@ -1,0 +1,33 @@
+import React from "react";
+import styled from "styled-components";
+
+export default function SocialBtnContainer(props) {
+  return (
+    <Head>
+      <div className="small_categories"></div>
+      <div className="social_btn">
+        <button>↑ SHARE</button>
+        <button>+ PORTFOLIO</button>
+        <button>+ FOLLOW</button>
+      </div>
+    </Head>
+  );
+}
+const Head = styled.div`
+  ${({ theme }) => theme.flexCenter};
+  height: 60px;
+  justify-content: space-between;
+  .small_categories {
+    width: 10px;
+  }
+  .social_btn {
+    button {
+      padding: 4px 12px;
+      margin: 2px;
+      border-radius: 15px;
+      border: 0.5px solid black;
+      font-size: 14px;
+      font-weight: 600;
+    }
+  }
+`;

--- a/src/Pages/ItemDetail/Components/Form.js
+++ b/src/Pages/ItemDetail/Components/Form.js
@@ -1,0 +1,48 @@
+/* eslint-disable prettier/prettier */
+import React, { useState } from "react";
+import styled from "styled-components";
+import MarketSummary from "./Container/MarketSummary";
+import SocialBtnContainer from "./Container/SocialBtnContainer";
+import ProductSummary from "./Container/ProductSummary";
+import ItemImage from "./Container/ItemImage";
+import ScrollSlider from "./Container/ScrollSlider";
+import ProductInfo from "./Container/ProductInfo";
+
+export default function Form({ itemData, updateIdx, dataIdx }) {
+  const [scrollValue, setScrollValue] = useState(0);
+  const handleScrollValue = e => {
+    setScrollValue(e.target.value);
+  };
+  // console.log(itemData.results.product_ticker);
+  return (
+    <Format>
+      <SocialBtnContainer />
+      <h1>{itemData.results?.product_name}</h1>
+      <ProductSummary ticker={itemData.results?.product_ticker} />
+      <MarketSummary
+        sizes={itemData.results?.sizes}
+        updateIdx={updateIdx}
+        dataIdx={dataIdx}
+      />
+      <ItemImage imageIdx={scrollValue} images={itemData.results?.image_url} />
+      {itemData.results?.product_ticker === "AJ6-BI19" && (
+        <ScrollSlider handleScrollValue={handleScrollValue} />
+      )}
+      <ProductInfo product={itemData.results} />
+    </Format>
+  );
+}
+
+const Format = styled.div`
+  max-width: 84vw;
+  display: block;
+  justify-content: left;
+  padding: 0 15px;
+  margin: 0 auto;
+
+  h1 {
+    max-width: 70%;
+    font-size: 55px;
+    font-weight: 700;
+  }
+`;

--- a/src/Pages/ItemDetail/Components/History/ChartData.js
+++ b/src/Pages/ItemDetail/Components/History/ChartData.js
@@ -1,0 +1,13 @@
+import React, { Component } from "react";
+import { ChartMockData } from "./MockData/Options";
+import High from "./High";
+
+export default class ChartData extends Component {
+  constructor() {
+    super();
+    this.state = { ChartMockData };
+  }
+  render() {
+    return <High data={this.state.data} />;
+  }
+}

--- a/src/Pages/ItemDetail/Components/History/ChartHead.js
+++ b/src/Pages/ItemDetail/Components/History/ChartHead.js
@@ -1,0 +1,22 @@
+import React from "react";
+import styled from "styled-components";
+
+function ChartHead(props) {
+  return (
+    <Head>
+      <th>SIZE</th>
+      <th>SALE PRICE</th>
+      <th>DATE</th>
+      <th>TIME</th>
+    </Head>
+  );
+}
+
+export default ChartHead;
+
+const Head = styled.div`
+  th {
+    font-size: 16px;
+    padding: 2px 6px;
+  }
+`;

--- a/src/Pages/ItemDetail/Components/History/High.js
+++ b/src/Pages/ItemDetail/Components/History/High.js
@@ -1,0 +1,11 @@
+import React, { Component } from "react";
+import Highcharts from "highcharts";
+import HighchartsReact from "highcharts-react-official";
+import { Options } from "./MockData/Options";
+
+class High extends Component {
+  render() {
+    return <HighchartsReact highcharts={Highcharts} options={Options} />;
+  }
+}
+export default High;

--- a/src/Pages/ItemDetail/Components/History/HistoryBox.js
+++ b/src/Pages/ItemDetail/Components/History/HistoryBox.js
@@ -1,0 +1,64 @@
+import React from "react";
+import styled from "styled-components";
+
+function HistoryBox({ sizes }) {
+  console.log(sizes);
+  return (
+    <Container>
+      <HistoryHead>12 MONTH HISTORICAL</HistoryHead>
+      <Box>
+        <h1># OF SALES</h1>
+        <p>{sizes?.total_sales}</p>
+      </Box>
+      <Box>
+        <h1>PRICE PREMIUM</h1>
+        {sizes?.price_premium > 0 ? (
+          <p>{sizes?.price_premium}%</p>
+        ) : (
+          <p className="red">{sizes?.price_premium}%</p>
+        )}
+      </Box>
+      <Box>
+        <h1>AVERAGE SALE PRICE</h1>
+        <p>{sizes?.average_sale_price}</p>
+      </Box>
+    </Container>
+  );
+}
+
+export default HistoryBox;
+
+const Container = styled.div`
+  width: 360px;
+  height: 100%;
+  font-size: 16px;
+  font-weight: 600;
+`;
+
+const HistoryHead = styled.div`
+  ${({ theme }) => theme.flexCenter};
+  height: 84px;
+`;
+
+const Box = styled.div`
+  padding-top: 20px;
+  flex-direction: 1;
+  border-top: 1px solid lightgray;
+  p,
+  h1 {
+    text-align: center;
+    margin: 20px;
+  }
+  h1 {
+    font-size: 24px;
+    font-weight: 700;
+  }
+  p {
+    font-size: 36px;
+    color: #08a05c;
+    padding-bottom: 22px;
+  }
+  .red {
+    color: #ff6060;
+  }
+`;

--- a/src/Pages/ItemDetail/Components/History/HistoryChart.js
+++ b/src/Pages/ItemDetail/Components/History/HistoryChart.js
@@ -1,0 +1,55 @@
+/* eslint-disable prettier/prettier */
+import React from "react";
+import styled from "styled-components";
+
+export default function HistoryChart({ salesHistory, sizes }) {
+  return (
+    <ChartContainer>
+      <table>
+        <thead>
+          <tr className="tablehead">
+            <th>SIZE</th>
+            <th>SALE PRICE</th>
+            <th>DATE</th>
+            <th>TIME</th>
+          </tr>
+        </thead>
+        <tbody>
+          {salesHistory?.map((history, idx) => {
+            return (
+              <tr className="tablebody">
+                <td>{sizes.size_name}</td>
+                <td>${history.sale_price}</td>
+                <td>{history.date_time}</td>
+                <td>{history.time}</td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </ChartContainer>
+  );
+}
+
+const ChartContainer = styled.div`
+  ${({ theme }) => theme.flexCenter};
+  font-size: 14px;
+
+  th,
+  td {
+    text-align: center;
+    width: 150px;
+    padding: 5px;
+    text-align: start;
+  }
+  .tablehead {
+    border-bottom: 2px solid lightgray;
+    font-weight: 700;
+    background-color: white;
+    font-size: 16px;
+  }
+
+  .tablebody:nth-child(odd) {
+    background-color: #f5f5f5;
+  }
+`;

--- a/src/Pages/ItemDetail/Components/History/MockData/Options.js
+++ b/src/Pages/ItemDetail/Components/History/MockData/Options.js
@@ -1,0 +1,92 @@
+import Highcharts from "highcharts";
+
+export const ChartMockData = {
+  data: [
+    530,
+    500,
+    535,
+    540,
+    500,
+    510,
+    520,
+    535,
+    525,
+    550,
+    555,
+    520,
+    535,
+    540,
+    525,
+    530,
+    510,
+    500,
+    550,
+    510,
+    520,
+    535,
+    540,
+    510,
+    500,
+    550,
+    530,
+    530,
+    525,
+    535,
+    540,
+  ],
+};
+export const Options = {
+  chart: {
+    type: "areaspline", // bar차트. 아무 설정이 없으면 line chart가 된다.
+  },
+  title: {
+    text: "",
+  },
+  credits: {
+    enabled: false,
+  },
+  xAxis: {
+    type: "monthtime",
+  },
+  yAxis: {
+    title: {
+      text: "",
+    },
+  },
+  legend: {
+    enabled: false,
+  },
+  plotOptions: {
+    area: {
+      fillColor: {
+        linearGradient: {
+          x1: 0,
+          y1: 0,
+          x2: 0,
+          y2: 1,
+        },
+        stops: [
+          [0, Highcharts.getOptions().colors[2]],
+          [
+            2,
+            Highcharts.color(Highcharts.getOptions().colors[2])
+              .setOpacity(0)
+              .get("rgba"),
+          ],
+        ],
+      },
+      marker: {
+        radius: 0,
+      },
+      lineWidth: 1,
+      lineColor: 1,
+      states: {
+        hover: {
+          lineWidth: 1,
+        },
+      },
+      threshold: null,
+    },
+  },
+  series: [{ type: "area", name: "data", data: ChartMockData.data }],
+};

--- a/src/Pages/ItemDetail/Components/LabelBanner.js
+++ b/src/Pages/ItemDetail/Components/LabelBanner.js
@@ -1,0 +1,25 @@
+import React from "react";
+import styled from "styled-components";
+
+export default function LabelBanner(props) {
+  return (
+    <Banner>
+      <SectionBanner>LATEST SALE</SectionBanner>
+    </Banner>
+  );
+}
+
+const Banner = styled.div`
+  ${({ theme }) => theme.flexCenter}
+  align-items: flex-start;
+  height: 50px;
+`;
+
+const SectionBanner = styled.div`
+  ${({ theme }) => theme.flexCenter}
+  height: 40px;
+  background-color: #2e2e2e;
+  padding: 4px 16px;
+  font-weight: 600;
+  color: white;
+`;

--- a/src/Pages/ItemDetail/Components/MarketHistoryForm.js
+++ b/src/Pages/ItemDetail/Components/MarketHistoryForm.js
@@ -1,0 +1,37 @@
+import React, { useState } from "react";
+import styled from "styled-components";
+import LabelBanner from "../Components/LabelBanner";
+import HistoryChart from "./History/HistoryChart";
+import HistoryBox from "./History/HistoryBox";
+import ChartData from "./History/ChartData";
+
+export default function MarketHistoryForm({ itemData, updateIdx, dataIdx }) {
+  return (
+    <Format>
+      <LabelBanner />
+      <MainContainer>
+        <div className="MainSection">
+          <ChartData />
+          <HistoryChart
+            salesHistory={itemData.results?.sizes[dataIdx].sales_history}
+            sizes={itemData.results?.sizes[dataIdx]}
+          />
+        </div>
+        <HistoryBox sizes={itemData.results?.sizes[dataIdx]} />
+      </MainContainer>
+    </Format>
+  );
+}
+
+const Format = styled.div`
+  border-top: 1px solid lightgray;
+`;
+
+const MainContainer = styled.div`
+  display: flex;
+  max-width: 84vw;
+  margin: 0 auto;
+  .MainSection {
+    width: 60%;
+  }
+`;

--- a/src/Pages/ItemDetail/ItemDetail.js
+++ b/src/Pages/ItemDetail/ItemDetail.js
@@ -1,21 +1,39 @@
-import React from "react";
-import { useHistory } from "react-router-dom";
+/* eslint-disable prettier/prettier */
+import React, { useState, useEffect } from "react";
+import Form from "./Components/Form";
+import MarketHistoryForm from "./Components/MarketHistoryForm";
+import { ITEMDETAILAPI } from "../../Config";
 
-const ItemDetail = (props) => {
-  const history = useHistory();
-  const goToBuy = () => {
-    history.push("/order/buy");
+export default function ItemDetail() {
+  const [itemData, setItemData] = useState([]);
+  const [dataIdx, setDataIdx] = useState(0);
+  const updateIdx = buttonId => {
+    setDataIdx(buttonId);
   };
 
-  const goToSell = () => {
-    history.push("/order/sell");
+  const getItemData = () => {
+    fetch(`${ITEMDETAILAPI}`)
+      .then(res => res.json())
+      .then(res => setItemData(res));
   };
+
+  // const getItemData = () => {
+  //   fetch("./Data/ItemDetailData.json")
+  //     .then(res => res.json())
+  //     .then(res => setItemData(res));
+  // };
+
+  useEffect(() => {
+    getItemData();
+  }, []);
   return (
-    <div>
-      <button onClick={goToBuy}>Buy</button>
-      <button onClick={goToSell}>Sell</button>
-    </div>
+    <>
+      <Form itemData={itemData} updateIdx={updateIdx} dataIdx={dataIdx} />
+      <MarketHistoryForm
+        itemData={itemData}
+        updateIdx={updateIdx}
+        dataIdx={dataIdx}
+      />
+    </>
   );
-};
-
-export default ItemDetail;
+}

--- a/src/Pages/Mypage/Mypage.js
+++ b/src/Pages/Mypage/Mypage.js
@@ -1,3 +1,4 @@
+/* eslint-disable prettier/prettier */
 import React, { useState } from "react";
 import MenuTab from "./Components/MenuTab";
 import BuyingSelling from "./Components/BuyingSelling";
@@ -7,7 +8,7 @@ import styled from "styled-components";
 const Mypage = () => {
   const [currentMenu, setCurrentMenu] = useState(2);
 
-  const menuHandler = (id) => {
+  const menuHandler = id => {
     setCurrentMenu(id);
   };
 

--- a/src/Pages/Mypage/Portfolio.js
+++ b/src/Pages/Mypage/Portfolio.js
@@ -1,0 +1,40 @@
+import React from "react";
+import styled from "styled-components";
+import ChartsContainer from "./PortfolioContainer/ChartsContainer";
+import HeaderZone from "./PortfolioContainer/HeaderZone";
+import TotalContainer from "./PortfolioContainer/TotalContainer";
+import ListContainer from "./PortfolioContainer/ListContainer";
+
+function Portfolio(props) {
+  return (
+    <PortfolioPage>
+      <ASIDE />
+      <PortfolioContainer>
+        <HeaderZone />
+        <ChartZone>
+          <ChartsContainer />
+          <TotalContainer />
+        </ChartZone>
+        <ListContainer />
+      </PortfolioContainer>
+    </PortfolioPage>
+  );
+}
+
+export default Portfolio;
+
+const PortfolioPage = styled.div`
+  ${({ theme }) => theme.flexCenter}
+`;
+const ASIDE = styled.div`
+  width: 265px;
+  background-color: lightgray;
+`;
+const ChartZone = styled.div`
+  display: flex;
+`;
+const PortfolioContainer = styled.div`
+  width: 1152px;
+  margin: 0 auto;
+  padding: 16px 32px;
+`;

--- a/src/Pages/Mypage/PortfolioContainer/ChartsContainer.js
+++ b/src/Pages/Mypage/PortfolioContainer/ChartsContainer.js
@@ -1,0 +1,23 @@
+import React from "react";
+import PieChart from "./Components/PieChart";
+import TapMenu from "./Components/TapMenu";
+import styled from "styled-components";
+
+function ChartsContainer(props) {
+  return (
+    <div>
+      <TapMenu />
+      <Container>
+        <PieChart />
+        <PieChart />
+      </Container>
+    </div>
+  );
+}
+
+export default ChartsContainer;
+
+const Container = styled.div`
+  ${({ theme }) => theme.flexCenter}
+  background-color: pink;
+`;

--- a/src/Pages/Mypage/PortfolioContainer/Components/BlackBtn.js
+++ b/src/Pages/Mypage/PortfolioContainer/Components/BlackBtn.js
@@ -1,0 +1,16 @@
+import React from "react";
+import styled from "styled-components";
+
+const BlackBtn = () => {
+  return <BlackButton>Add</BlackButton>;
+};
+
+export default BlackBtn;
+
+const BlackButton = styled.button`
+  padding: 16px;
+  border-radius: 2px;
+  background-color: black;
+  color: white;
+  font-weight: 600;
+`;

--- a/src/Pages/Mypage/PortfolioContainer/Components/PieChart.js
+++ b/src/Pages/Mypage/PortfolioContainer/Components/PieChart.js
@@ -1,0 +1,21 @@
+import React from "react";
+import Highcharts from "highcharts";
+import HighchartsReact from "highcharts-react-official";
+import configObj from "../../../../utils/configObj";
+import styled from "styled-components";
+
+function PieChart(props) {
+  return (
+    <ChartContainer>
+      <HighchartsReact
+        highcharts={Highcharts}
+        options={configObj}
+        containerProps={{ style: { width: "300px", height: "360px" } }}
+      />
+    </ChartContainer>
+  );
+}
+
+export default PieChart;
+
+const ChartContainer = styled.div``;

--- a/src/Pages/Mypage/PortfolioContainer/Components/TapMenu.js
+++ b/src/Pages/Mypage/PortfolioContainer/Components/TapMenu.js
@@ -1,0 +1,23 @@
+import React from "react";
+import styled from "styled-components";
+
+function TapMenu(props) {
+  return (
+    <TapContainer>
+      <TapButton>Basic</TapButton>
+      <TapButton>Advanced</TapButton>
+    </TapContainer>
+  );
+}
+
+export default TapMenu;
+
+const TapContainer = styled.div`
+  border-bottom: 1px solid lightgray;
+`;
+
+const TapButton = styled.button`
+  font-size: 16px;
+  font-weight: 600;
+  padding: 8px 16px;
+`;

--- a/src/Pages/Mypage/PortfolioContainer/HeaderZone.js
+++ b/src/Pages/Mypage/PortfolioContainer/HeaderZone.js
@@ -1,0 +1,26 @@
+import React from "react";
+import BlackBtn from "./Components/BlackBtn";
+import styled from "styled-components";
+
+const HeaderZone = () => {
+  return (
+    <FlexBox>
+      <HeaderText>Your Portfolio</HeaderText>
+      <BlackBtn />
+    </FlexBox>
+  );
+};
+
+export default HeaderZone;
+
+const FlexBox = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  padding-bottom: 12px;
+  margin-bottom: 20px;
+`;
+const HeaderText = styled.h1`
+  font-size: 24px;
+  font-weight: 800;
+`;

--- a/src/Pages/Mypage/PortfolioContainer/ListContainer.js
+++ b/src/Pages/Mypage/PortfolioContainer/ListContainer.js
@@ -1,0 +1,61 @@
+/* eslint-disable prettier/prettier */
+import React from "react";
+import styled from "styled-components";
+
+function ListContainer(props) {
+  return (
+    <ChartContainer>
+      <table>
+        <thead>
+          <tr className="tablehead">
+            <th>NAME</th>
+            <th>PURCHASE DATE</th>
+            <th>PURCHASE PRICE</th>
+            <th>MARKET VALUE</th>
+            <th>GAIN/LOSS</th>
+          </tr>
+        </thead>
+        <tbody>
+          {/* {salesHistory?.map((history, idx) => {
+              return ( */}
+          <tr className="tablebody">
+            <td>JORDAN 1 RETRO HIGH</td>
+            <td>03/31/2020</td>
+            <td>$350</td>
+            <td>$450</td>
+            <GainLoss>100%</GainLoss>
+          </tr>
+          {/* );
+            })} */}
+        </tbody>
+      </table>
+    </ChartContainer>
+  );
+}
+
+export default ListContainer;
+
+const ChartContainer = styled.div`
+  font-size: 14px;
+
+  th,
+  td {
+    text-align: center;
+    padding: 5px;
+    text-align: start;
+  }
+  .tablehead {
+    border-bottom: 2px solid lightgray;
+    font-weight: 700;
+    background-color: white;
+    font-size: 16px;
+  }
+
+  .tablebody:nth-child(odd) {
+    background-color: #f5f5f5;
+  }
+`;
+
+const GainLoss = styled.td`
+  color: ${props => props.theme.colors.green};
+`;

--- a/src/Pages/Mypage/PortfolioContainer/TotalContainer.js
+++ b/src/Pages/Mypage/PortfolioContainer/TotalContainer.js
@@ -1,0 +1,24 @@
+import React from "react";
+import styled from "styled-components";
+
+function TotalContainer(props) {
+  return (
+    <Form>
+      <Empty>*</Empty>
+      <body>a</body>
+    </Form>
+  );
+}
+
+export default TotalContainer;
+
+const Form = styled.div`
+  width: 30%;
+  border-bottom: 1px solid lightgray;
+`;
+
+const Empty = styled.button`
+  font-size: 16px;
+  font-weight: 600;
+  padding: 8px 16px;
+`;

--- a/src/Pages/Payment/Payment.js
+++ b/src/Pages/Payment/Payment.js
@@ -1,3 +1,4 @@
+/* eslint-disable prettier/prettier */
 import React, { useEffect, useState } from "react";
 import styled from "styled-components";
 import { useParams, useHistory } from "react-router-dom";
@@ -87,8 +88,8 @@ const Payment = () => {
         Authorization: localStorage.getItem("Kakao_token"),
       },
     })
-      .then((res) => res.json())
-      .then((data) => {
+      .then(res => res.json())
+      .then(data => {
         setDetailData(data.data.product);
         setInputs({
           name: data.data.shippingInfo.name,
@@ -125,8 +126,8 @@ const Payment = () => {
         expirationDate: expirationNum,
       }),
     })
-      .then((res) => res.json())
-      .then((res) => {
+      .then(res => res.json())
+      .then(res => {
         if (res.message === "SUCCESS") {
           alert("Your Order is Confirmed!");
           history.push("/");
@@ -134,32 +135,32 @@ const Payment = () => {
       });
   };
 
-  const changeIdxHanlder = (idx) => {
+  const changeIdxHanlder = idx => {
     if (idx < 2) {
       setCurrentIdx(idx + 1);
     }
   };
-  const changeTabHandler = (id) => {
+  const changeTabHandler = id => {
     setIsPlace(id);
     setIsBid(!isBid);
     setIsAsk(!isAsk);
   };
 
-  const handleInputNum = (e) => {
+  const handleInputNum = e => {
     setInputs({
       ...inputs,
       [e.name]: e.value,
     });
   };
 
-  const handleInputInfo = (e) => {
+  const handleInputInfo = e => {
     setInputs({
       ...inputs,
       [e.name]: e.value,
     });
   };
 
-  const messageHandler = (e) => {
+  const messageHandler = e => {
     if (e.key === "Enter") {
       if (buyInput || sellInput) {
         setIsShowAddFeeList(true);
@@ -207,7 +208,7 @@ const Payment = () => {
     }
   };
 
-  const expirationHandler = (e) => {
+  const expirationHandler = e => {
     setExpirationNum(e.target.value);
   };
 

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -6,6 +6,7 @@ import ItemList from "./Pages/ItemList/ItemList";
 import Payment from "./Pages/Payment/Payment";
 import Mypage from "./Pages/Mypage/Mypage";
 import Main from "./Pages/Main/Main";
+import Portfolio from "./Pages/Mypage/Portfolio";
 
 class Routes extends React.Component {
   render() {
@@ -19,6 +20,7 @@ class Routes extends React.Component {
           <Route exact path="/order/:id" component={Payment} />
           <Route exact path="/product/detail/:id" component={ItemDetail} />
           <Route exact path="/mypage" component={Mypage} />
+          <Route exact path="/portfolio" component={Portfolio} />
         </Switch>
       </Router>
     );

--- a/src/utils/configObj.js
+++ b/src/utils/configObj.js
@@ -1,0 +1,55 @@
+const configObj = {
+  chart: {
+    plotBackgroundColor: null,
+    plotBorderWidth: null,
+    plotShadow: false,
+    type: "pie",
+    margin: [40],
+  },
+  title: {
+    text: "Item Count",
+  },
+  tooltip: {
+    pointFormat: "{series.name}: <b>{point.percentage:.1f}%</b>",
+  },
+  accessibility: {
+    point: {
+      valueSuffix: "%",
+    },
+  },
+  plotOptions: {
+    pie: {
+      allowPointSelect: false,
+      cursor: "pointer",
+      dataLabels: {
+        enabled: false,
+      },
+      showInLegend: true,
+    },
+  },
+  series: [
+    {
+      name: "Brands",
+      colorByPoint: true,
+      data: [
+        {
+          name: "Air Jordan",
+          y: 60,
+          color: "#F77068",
+        },
+        {
+          name: "Kobe",
+          y: 30,
+          color: "#4F71F7",
+        },
+        {
+          name: "Nike Bsketball",
+          y: 10,
+          color: "#9560FA",
+        },
+      ],
+    },
+  ],
+};
+
+export default configObj;


### PR DESCRIPTION
>wecode PR message template 및 체크 리스트 입니다. 
아래 사항들을 전부 작성/체크 하시고 PR 해주세요!

## 수정 사항 간략한 한줄 요약
(0311)
리뷰 반영하였습니다. 머지요청 드립니다!

(0308)
-백엔드와 데이터 키값, 형식 통일 => 통신 성공
-그래프 추가기능 구현중
-모달 조건문 추가
(0305)
-디테일 페이지 컴포넌트 나눠서 작업
		 
## 수정 사항들 자세한 내용
(0308)
-모달 조건문 추가 
: stock이 없을때 0으로 표시되도록 조건문 설정, 버튼을 누를때 버튼의 index를 읽어서 보여주는 해당하는 데이터의 index에 접근해서 렌더링을 바꿔줄 수 있도록 로직 구성
- 백엔드와 데이터 키값, 형식 통일 => 통신 성공
: https://www.notion.so/shockx/ShockX-492875264dcf45aeb97b64721abdfa6e
-그래프 추가기능 구현중
: 라이브러리를 활용해 그래프 추가구현을 해볼 예정임.
(0305)
-상품 슬라이더 추가, 모달기능 구현

## 기타 질문 및 특이 사항
Q1.
<img width="744" alt="스크린샷 2021-03-08 오전 10 51 03" src="https://user-images.githubusercontent.com/75440601/110264456-add78180-7ffc-11eb-9f8e-667cb32279e9.png">
모달에서 사이즈 클릭시마다 데이터 로딩이 달라지는 부분을
1. 버튼을 클릭할 때 버튼 idx 값을 읽고
2. 모달의 부모인 Itemdetail로 값을 올려줌
3. 다시 idx값의 자식->자식->자식 으로 넘겨주며 데이터를 뿌려주는 식으로 구성하였습니다.
줄일수 있는 로직이 있는지 궁금합니다!

Q2.
<img width="529" alt="스크린샷 2021-03-08 오전 10 58 02" src="https://user-images.githubusercontent.com/75440601/110264663-2c342380-7ffd-11eb-9dea-844fbb33ae24.png">
데이터와 색만 다르고, 스타일이 똑같은 두 버튼이 있을때, 코드를 줄일 수 있는 방법이 궁금합니다.
제가 작성한 "ActionButton.js"에서는 버튼 두개를 만들어 같은 코드를 적용하였습니다.

## 체크 리스트 (아래 사항들이 전부 체크되어야만 merge가 됩니다!)
- [x] 필요한 test들을 완료하였고 기능이 제대로 실행되는지 확인 하였습니다.
- [x] Wecode의 코드 스타일 가이드에 맞추어 코드를 작성 하였습니다.
- [x] 제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x] 본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 대하여 알고 있습니다.
- [x] Git rebase와 squash를 했고 커밋 수가 하나 인것을 확인 했습니다.
